### PR TITLE
Add support for h264 input file format

### DIFF
--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -3,8 +3,9 @@
 var Stream = require('../utils/stream.js');
 var ExpGolomb = require('../utils/exp-golomb.js');
 
-var H264Stream, NalByteStream;
+var H264Stream, NalByteStream, H264StreamParser;
 var PROFILES_WITH_OPTIONAL_SPS_DATA;
+var NAL_UNIT_TYPES;
 
 /**
  * Accepts a NAL unit byte stream and unpacks the embedded NAL units.
@@ -439,7 +440,452 @@ H264Stream = function() {
 };
 H264Stream.prototype = new Stream();
 
+NAL_UNIT_TYPES = {
+  UNSPECIFIED: 0,
+  CODED_SLICE_NON_IDR: 1,
+  CODED_SLICE_DATA_PARTITION_A: 2,
+  CODED_SLICE_DATA_PARTITION_B: 3,
+  CODED_SLICE_DATA_PARTITION_C: 4,
+  CODED_SLICE_IDR: 5,
+  SEI: 6,
+  SPS: 7,
+  PPS: 8,
+  AUD: 9,
+  END_OF_SEQUENCE: 10,
+  END_OF_STREAM: 11,
+  FILLER: 12,
+  SPS_EXT: 13,
+  CODED_SLICE_AUX: 19
+};
+
+H264StreamParser = function() {
+  var
+    self = this,
+    buffer,
+    iterator = 0,
+    startNalPosition = -1,
+    prevNalPosition = -1,
+    nalPosition = -1,
+    trackId = 1,
+    lastDts = 0,
+    frameCounter = 0,
+    separateColourPlaneFlag,
+    frameMbsOnlyFlag = 0,
+    picOrderCntType = 0,
+    picOrderCntLsbLength = 4,
+    log2MaxFrameNumMinus4Length = 4,
+    framerate = 90000 / 30, // initial 30 FPS, later read from SPS
+    prevPicOrderCntMsb = 0,
+    prevPicOrderCntLsb = 0,
+    maxPicOrderCntLsb,
+    bottomFieldPicOrderInFramePresentFlag = 0, // inital 0, later read from PPS
+    bytesDeliveredPosition = 0,
+    audEntry = [0, 0, 0, 1, 9, 240],
+    idrPicFlag = 0;
+
+  H264StreamParser.prototype.init.call(this);
+
+  this.push = function(data) {
+    var swapBuffer,
+        nalUnitType,
+        nalDataSps,
+        spsInfo,
+        nalDataPps,
+        maxNeededEndSliceLayer,
+        shInfo,
+        TopFieldOrderCnt,
+        BottomFieldOrderCnt,
+        PicOrderCntMsb,
+        PicOrderCnt,
+        pts,
+        dts,
+        extBuffer,
+        packetData;
+
+    if (!buffer) {
+      buffer = data;
+    } else {
+      swapBuffer = new Uint8Array(buffer.byteLength + data.byteLength -
+          bytesDeliveredPosition);
+      swapBuffer.set(buffer.subarray(bytesDeliveredPosition));
+      swapBuffer.set(data, buffer.byteLength - bytesDeliveredPosition);
+      buffer = swapBuffer;
+      prevNalPosition = prevNalPosition - bytesDeliveredPosition;
+      startNalPosition = startNalPosition - bytesDeliveredPosition;
+      iterator = iterator - bytesDeliveredPosition;
+      bytesDeliveredPosition = 0;
+    }
+
+    if (startNalPosition === -1) {
+      this.findFirstNalSyncPoint();
+    }
+
+    // Now startNalPosition should be correct. Else need more data
+    if (startNalPosition === -1) {
+      return;
+    }
+
+    // find next
+    while (this.findNextNalSyncPoint()) {
+      nalUnitType = buffer[prevNalPosition + 3] & 0x1F;
+      idrPicFlag = (nalUnitType === NAL_UNIT_TYPES.CODED_SLICE_IDR);
+
+
+      if (nalUnitType === NAL_UNIT_TYPES.SPS) {
+        nalDataSps = buffer.subarray(prevNalPosition + 3 + 1, nalPosition);
+        spsInfo = this.readSeqParameterSetData(nalDataSps);
+
+        // TODO what to do when framerate changes?
+        framerate = 90000 / ((spsInfo.timeScale / spsInfo.numUnitsInTick) / 2);
+      }
+      if (nalUnitType === NAL_UNIT_TYPES.PPS) {
+        nalDataPps = buffer.subarray(prevNalPosition + 3 + 1, nalPosition);
+        this.readPicParameterSetRbsp(nalDataPps);
+      }
+      if (nalUnitType <= NAL_UNIT_TYPES.CODED_SLICE_IDR) {
+
+        if (nalUnitType !== NAL_UNIT_TYPES.CODED_SLICE_IDR &&
+            nalUnitType !== NAL_UNIT_TYPES.CODED_SLICE_NON_IDR) {
+          // currently H264StreamParser supports only
+          // CODED_SLICE_IDR and CODED_SLICE_NON_IDR
+          // TODO add error report here
+          return;
+        }
+
+        maxNeededEndSliceLayer = (nalPosition - prevNalPosition > 32) ?
+            prevNalPosition + 32 : nalPosition;
+        shInfo = this.readSliceLayerWithoutPartitioningRbsp(
+            buffer.subarray(prevNalPosition + 3 + 1, maxNeededEndSliceLayer));
+
+        TopFieldOrderCnt = 0;
+        BottomFieldOrderCnt = 0;
+        PicOrderCntMsb = 0;
+        PicOrderCnt = 0;
+        if (nalUnitType === NAL_UNIT_TYPES.CODED_SLICE_IDR) {
+          lastDts = lastDts + frameCounter * framerate;
+          frameCounter = 1;
+          prevPicOrderCntMsb = 0;
+          prevPicOrderCntLsb = 0;
+        }
+        // compute PicOrderCntMsb, TopFieldOrderCnt according to
+        // 8.2.1.1 Decoding process for picture order count type 0
+        if (nalUnitType === NAL_UNIT_TYPES.CODED_SLICE_NON_IDR) {
+          frameCounter++;
+          if ((shInfo.picOrderCntLsb < prevPicOrderCntLsb) &&
+              ((prevPicOrderCntLsb - shInfo.picOrderCntLsb) >= (maxPicOrderCntLsb / 2))) {
+            PicOrderCntMsb = prevPicOrderCntMsb + maxPicOrderCntLsb;
+          } else if ((shInfo.picOrderCntLsb > prevPicOrderCntLsb) &&
+              ((shInfo.picOrderCntLsb - prevPicOrderCntLsb) > (maxPicOrderCntLsb / 2))) {
+            PicOrderCntMsb = prevPicOrderCntMsb - maxPicOrderCntLsb;
+          } else {
+            PicOrderCntMsb = prevPicOrderCntMsb;
+          }
+          TopFieldOrderCnt = PicOrderCntMsb + shInfo.picOrderCntLsb;
+          if (!shInfo.fieldPicFlag) {
+            BottomFieldOrderCnt = TopFieldOrderCnt + shInfo.deltaPicOrderCntBottom;
+          } else {
+            BottomFieldOrderCnt = PicOrderCntMsb + shInfo.picOrderCntLsb;
+          }
+          PicOrderCnt = Math.min(TopFieldOrderCnt, BottomFieldOrderCnt);
+        }
+
+        prevPicOrderCntMsb = PicOrderCntMsb;
+        prevPicOrderCntLsb = shInfo.picOrderCntLsb;
+
+        dts = lastDts + (frameCounter - 1) * framerate;
+        pts = lastDts + (PicOrderCnt / 2) * framerate;
+
+        extBuffer = new Uint8Array(nalPosition - startNalPosition + audEntry.length);
+        extBuffer.set(audEntry);
+        extBuffer.set(buffer.subarray(startNalPosition, nalPosition), audEntry.length);
+
+        packetData = extBuffer;
+        startNalPosition = nalPosition;
+        bytesDeliveredPosition = startNalPosition;
+
+        if (nalUnitType === NAL_UNIT_TYPES.CODED_SLICE_IDR) { // I-frame
+          if (lastDts > 0) { // and not the first one
+            // flush the rest of pipeline then add packet with new I-frame
+            self.flush();
+          }
+        }
+
+        var event = {
+          type: 'video',
+          trackId: trackId,
+          pts: pts,
+          dts: dts,
+          data: packetData
+        };
+
+        self.trigger('data', event);
+      }
+      prevNalPosition = nalPosition;
+    }
+  };
+
+  this.findFirstNalSyncPoint = function() {
+    var i = 0;
+
+    for (; i < buffer.byteLength - 3; i++) {
+      if (buffer[i] === 0 &&
+          buffer[i + 1] === 0 &&
+          buffer[i + 2 ] === 1) {
+        nalPosition = prevNalPosition = startNalPosition = i;
+        break;
+      }
+    }
+    iterator = i;
+  };
+
+  this.findNextNalSyncPoint = function() {
+    var i = iterator + 4;
+
+    for (; i < buffer.byteLength - 3; i++) {
+      if ((buffer[i] === 0) &&
+           buffer[i + 1] === 0 &&
+           buffer[i + 2] === 1) {
+        nalPosition = i;
+        iterator = i;
+        return true;
+      }
+    }
+    iterator = i;
+    return false;
+  };
+
+  this.removeEmulationPreventionByte = function(data) {
+    var tmpBuffer = new Uint8Array(data.byteLength);
+    var i, startByte = 0, totalBytes = 0;
+
+    for (i = 0; i < tmpBuffer.byteLength - 2; i++) {
+      if (data[i] === 0 &&
+          data[i + 1] === 0 &&
+          data[i + 2] === 3) {
+          // remove emulation prevention
+            tmpBuffer.set(data.subarray(startByte, i + 2), totalBytes);
+            totalBytes += i + 2 - startByte;
+            startByte = i + 3;
+            i += 2;
+            continue;
+      }
+    }
+    tmpBuffer.set(data.subarray(startByte, i + 2), totalBytes);
+    return tmpBuffer;
+  };
+
+  /**
+   * Advance the ExpGolomb decoder past a scaling list. The scaling
+   * list is optionally transmitted as part of a sequence parameter
+   * set and is not relevant to transmuxing.
+   * @param count {number} the number of entries in this scaling list
+   * @param expGolombDecoder {object} an ExpGolomb pointed to the
+   * start of a scaling list
+   * @see Recommendation ITU-T H.264, Section 7.3.2.1.1.1
+   */
+  this.skipScalingList = function(count, expGolombDecoder) {
+    var
+      lastScale = 8,
+      nextScale = 8,
+      j,
+      deltaScale;
+
+    for (j = 0; j < count; j++) {
+      if (nextScale !== 0) {
+        deltaScale = expGolombDecoder.readExpGolomb();
+        nextScale = (lastScale + deltaScale + 256) % 256;
+      }
+
+      lastScale = (nextScale === 0) ? lastScale : nextScale;
+    }
+  };
+
+  this.readSeqParameterSetData = function(dataEm) {
+    var
+      expGolombDecoder, profileIdc,
+      chromaFormatIdc,
+      numRefFramesInPicOrderCntCycle,
+      scalingListCount,
+      aspectRatioIdc,
+      numUnitsInTick,
+      timeScale = -1,
+      fixedFrameRateFlag = -1,
+      log2MaxPicOrderCntLsbMinus4,
+      i,
+      data;
+
+    data = this.removeEmulationPreventionByte(dataEm);
+    separateColourPlaneFlag = 0;
+
+    expGolombDecoder = new ExpGolomb(data);
+
+    profileIdc = expGolombDecoder.readUnsignedByte(); // profile_idc
+    expGolombDecoder.skipBits(8); // constraint_set[0-5]_flag
+    expGolombDecoder.skipBits(8); // level_idc u(8)
+    expGolombDecoder.skipUnsignedExpGolomb(); // seq_parameter_set_id
+
+    // some profiles have more optional data we don't need
+    if (PROFILES_WITH_OPTIONAL_SPS_DATA[profileIdc]) {
+      chromaFormatIdc = expGolombDecoder.readUnsignedExpGolomb();
+      if (chromaFormatIdc === 3) {
+        separateColourPlaneFlag = expGolombDecoder.readBits(1); // separate_colour_plane_flag
+      }
+      expGolombDecoder.skipUnsignedExpGolomb(); // bit_depth_luma_minus8
+      expGolombDecoder.skipUnsignedExpGolomb(); // bit_depth_chroma_minus8
+      expGolombDecoder.skipBits(1); // qpprime_y_zero_transform_bypass_flag
+      if (expGolombDecoder.readBoolean()) { // seq_scaling_matrix_present_flag
+        scalingListCount = (chromaFormatIdc !== 3) ? 8 : 12;
+        for (i = 0; i < scalingListCount; i++) {
+          if (expGolombDecoder.readBoolean()) { // seq_scaling_list_present_flag[ i ]
+            if (i < 6) {
+              this.skipScalingList(16, expGolombDecoder);
+            } else {
+              this.skipScalingList(64, expGolombDecoder);
+            }
+          }
+        }
+      }
+    }
+
+    log2MaxFrameNumMinus4Length = expGolombDecoder.readUnsignedExpGolomb() + 4; // log2_max_frame_num_minus4
+    picOrderCntType = expGolombDecoder.readUnsignedExpGolomb(); // pic_order_cnt_type
+
+    if (picOrderCntType === 0) {
+      log2MaxPicOrderCntLsbMinus4 = expGolombDecoder.readUnsignedExpGolomb(); // log2_max_pic_order_cnt_lsb_minus4
+    } else if (picOrderCntType === 1) {
+      expGolombDecoder.skipBits(1); // delta_pic_order_always_zero_flag
+      expGolombDecoder.skipExpGolomb(); // offset_for_non_ref_pic
+      expGolombDecoder.skipExpGolomb(); // offset_for_top_to_bottom_field
+      numRefFramesInPicOrderCntCycle = expGolombDecoder.readUnsignedExpGolomb();
+      for (i = 0; i < numRefFramesInPicOrderCntCycle; i++) {
+        expGolombDecoder.skipExpGolomb(); // offset_for_ref_frame[ i ]
+      }
+    }
+
+    expGolombDecoder.skipUnsignedExpGolomb(); // max_num_ref_frames
+    expGolombDecoder.skipBits(1); // gaps_in_frame_num_value_allowed_flag
+
+    expGolombDecoder.skipExpGolomb(); // pic_width_in_mbs_minus1
+    expGolombDecoder.skipExpGolomb(); // pic_height_in_map_units_minus1
+
+    frameMbsOnlyFlag = expGolombDecoder.readBits(1); // frame_mbs_only_flag
+    if (frameMbsOnlyFlag === 0) {
+      expGolombDecoder.skipBits(1); // mb_adaptive_frame_field_flag
+    }
+
+    expGolombDecoder.skipBits(1); // direct_8x8_inference_flag
+    if (expGolombDecoder.readBoolean()) { // frame_cropping_flag
+      expGolombDecoder.skipExpGolomb(); // frame_crop_left_offset
+      expGolombDecoder.skipExpGolomb(); // frame_crop_right_offset
+      expGolombDecoder.skipExpGolomb(); // frame_crop_top_offset
+      expGolombDecoder.skipExpGolomb(); // frame_crop_bottom_offset
+    }
+    if (expGolombDecoder.readBoolean()) {
+      // vui_parameters_present_flag
+      if (expGolombDecoder.readBoolean()) {
+        // aspect_ratio_info_present_flag
+        aspectRatioIdc = expGolombDecoder.readUnsignedByte();
+        switch (aspectRatioIdc) {
+          case 255: {
+            expGolombDecoder.skipBits(16); // sar_width
+            expGolombDecoder.skipBits(16); // sar_height
+            break;
+          }
+        }
+      }
+      if (expGolombDecoder.readBoolean()) {
+        // overscan_info_present_flag
+        expGolombDecoder.skipBits(1); // overscan_appropriate_flag
+      }
+      if (expGolombDecoder.readBoolean()) {
+        // video_signal_type_present_flag
+        expGolombDecoder.skipBits(3); // video_format
+        expGolombDecoder.skipBits(1); // video_full_range_flag
+        if (expGolombDecoder.readBoolean()) {
+        // colour_description_present_flag
+          expGolombDecoder.skipBits(8); // colour_primaries
+          expGolombDecoder.skipBits(8); // transfer_characteristics
+          expGolombDecoder.skipBits(8); // matrix_coefficients
+        }
+      }
+      if (expGolombDecoder.readBoolean()) {
+        // chroma_loc_info_present_flag
+        expGolombDecoder.readUnsignedExpGolomb(); // chroma_sample_loc_type_top_field
+        expGolombDecoder.readUnsignedExpGolomb(); // chroma_sample_loc_type_bottom_field
+      }
+      if (expGolombDecoder.readBoolean()) {
+        // timing_info_present_flag
+        numUnitsInTick = expGolombDecoder.readUnsignedByte() << 24 | // num_units_in_tick u(32)
+          expGolombDecoder.readUnsignedByte() << 16 |
+          expGolombDecoder.readUnsignedByte() << 8 |
+          expGolombDecoder.readUnsignedByte();
+        timeScale = expGolombDecoder.readUnsignedByte() << 24 | // time_scale u(32)
+          expGolombDecoder.readUnsignedByte() << 16 |
+          expGolombDecoder.readUnsignedByte() << 8 |
+          expGolombDecoder.readUnsignedByte();
+        fixedFrameRateFlag = expGolombDecoder.readBoolean(); // fixed_frame_rate_flag
+      }
+    }
+    maxPicOrderCntLsb = Math.pow(2, log2MaxPicOrderCntLsbMinus4 + 4);
+    picOrderCntLsbLength = log2MaxPicOrderCntLsbMinus4 + 4;
+    return {
+      numUnitsInTick: numUnitsInTick,
+      timeScale: timeScale,
+      fixedFrameRateFlag: fixedFrameRateFlag
+    };
+  };
+
+  this.readPicParameterSetRbsp = function(data) {
+    var expGolombDecoder = new ExpGolomb(data);
+
+    expGolombDecoder.skipExpGolomb(); // pic_parameter_set_id
+    expGolombDecoder.skipExpGolomb(); // seq_parameter_set_id
+    expGolombDecoder.skipBits(1); // entropy_coding_mode_flag
+    bottomFieldPicOrderInFramePresentFlag = expGolombDecoder.readBoolean(); // bottom_field_pic_order_in_frame_present_flag
+  };
+
+  this.readSliceLayerWithoutPartitioningRbsp = function(data) {
+    var
+      fieldPicFlag = 0,
+      deltaPicOrderCntBottom = 0,
+      picOrderCntLsb = -1;
+
+    var expGolombDecoder = new ExpGolomb(data);
+
+    expGolombDecoder.skipExpGolomb(); // first_mb_in_slice
+    expGolombDecoder.skipExpGolomb(); // slice_type
+    expGolombDecoder.skipExpGolomb(); // pic_parameter_set_id
+    if (separateColourPlaneFlag) {
+      expGolombDecoder.skipBits(2); // colour_plane_id
+    }
+    expGolombDecoder.skipBits(log2MaxFrameNumMinus4Length); // frame_num
+    if (!frameMbsOnlyFlag) {
+      fieldPicFlag = expGolombDecoder.readBits(1); // field_pic_flag
+      if (fieldPicFlag) {
+        expGolombDecoder.skipBits(1); // bottom_field_flag
+      }
+    }
+    if (idrPicFlag) {
+      expGolombDecoder.skipExpGolomb(); // idr_pic_id
+    }
+    if (!picOrderCntType) {
+      picOrderCntLsb = expGolombDecoder.readBits(picOrderCntLsbLength); // pic_order_cnt_lsb
+      if (bottomFieldPicOrderInFramePresentFlag && !fieldPicFlag) {
+        deltaPicOrderCntBottom = expGolombDecoder.readExpGolomb(); // delta_pic_order_cnt_bottom
+      }
+    }
+    return {
+      picOrderCntLsb: picOrderCntLsb,
+      fieldPicFlag: fieldPicFlag,
+      deltaPicOrderCntBottom: deltaPicOrderCntBottom
+    };
+  };
+};
+
+H264StreamParser.prototype = new Stream();
+
 module.exports = {
   H264Stream: H264Stream,
-  NalByteStream: NalByteStream
+  NalByteStream: NalByteStream,
+  H264StreamParser: H264StreamParser
 };

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -18,6 +18,7 @@ var trackDecodeInfo = require('./track-decode-info');
 var m2ts = require('../m2ts/m2ts.js');
 var AdtsStream = require('../codecs/adts.js');
 var H264Stream = require('../codecs/h264').H264Stream;
+var H264StreamParser = require('../codecs/h264').H264StreamParser;
 var AacStream = require('../aac');
 var isLikelyAacData = require('../aac/utils').isLikelyAacData;
 
@@ -40,6 +41,19 @@ var VIDEO_PROPERTIES = [
 
 // object types
 var VideoSegmentStream, AudioSegmentStream, Transmuxer, CoalesceStream;
+
+/**
+ * Check if first four byte looks like NAL
+ */
+var isLikelyH264BitstreamData = function(data) {
+  if ((data[0] === 0) &&
+      (data[1] === 0) &&
+      (data[2] === 0) &&
+      (data[3] === 1)) {
+    return true;
+  }
+  return false;
+};
 
 /**
  * Compare two arrays (even typed) for same-ness
@@ -752,7 +766,9 @@ CoalesceStream.prototype.flush = function(flushSource) {
 
   // We add this to every single emitted segment even though we only need
   // it for the first
-  event.metadata.dispatchType = this.metadataStream.dispatchType;
+  if (this.metadataStream) {
+    event.metadata.dispatchType = this.metadataStream.dispatchType;
+  }
 
   // Reset stream state
   this.pendingTracks.length = 0;
@@ -955,6 +971,40 @@ Transmuxer = function(options) {
     pipeline.coalesceStream.on('done', this.trigger.bind(this, 'done'));
   };
 
+  this.setupH264Pipeline = function() {
+    var pipeline = {};
+
+    this.transmuxPipeline_ = pipeline;
+    pipeline.type = 'h264';
+
+    // set up the parsing pipeline
+    pipeline.h264StreamParser = new H264StreamParser();
+    pipeline.h264Stream = new H264Stream();
+    pipeline.captionStream = new m2ts.CaptionStream();
+    pipeline.coalesceStream = new CoalesceStream(options);
+
+    videoTrack = {
+      timelineStartInfo: {
+        baseMediaDecodeTime: 0
+      },
+      type: 'video'
+    };
+
+    pipeline.videoSegmentStream = new VideoSegmentStream(videoTrack, options);
+
+    pipeline.headOfPipeline = pipeline.h264StreamParser;
+
+    pipeline.h264StreamParser
+      .pipe(pipeline.h264Stream);
+
+    pipeline.h264Stream
+            .pipe(pipeline.videoSegmentStream)
+            .pipe(pipeline.coalesceStream);
+
+    pipeline.coalesceStream.on('data',
+        this.trigger.bind(this, 'data')
+        );
+  };
   // hook up the segment streams once track metadata is delivered
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
     var pipeline = this.transmuxPipeline_;
@@ -1009,11 +1059,18 @@ Transmuxer = function(options) {
   this.push = function(data) {
     if (hasFlushed) {
       var isAac = isLikelyAacData(data);
+      var isH264 = isLikelyH264BitstreamData(data);
 
-      if (isAac && this.transmuxPipeline_.type !== 'aac') {
-        this.setupAacPipeline();
-      } else if (!isAac && this.transmuxPipeline_.type !== 'ts') {
-        this.setupTsPipeline();
+      if (isAac) {
+        if (this.transmuxPipeline_.type !== 'aac') {
+          this.setupAacPipeline();
+        }
+      } else if (isH264) {
+        if (this.transmuxPipeline_.type !== 'h264') {
+          this.setupH264Pipeline();
+        }
+      } else if (this.transmuxPipeline_.type !== 'ts') {
+          this.setupTsPipeline();
       }
       hasFlushed = false;
     }


### PR DESCRIPTION
So far only mpeg2 input format was accepted. This patch change the input
format to H264 bitstream.

This patch solves issue https://github.com/videojs/mux.js/issues/144

Signed-off-by: Grzegorz Wolny <g.wolny@samsung.com>

Conflicts:
	lib/mp4/transmuxer.js